### PR TITLE
Improved tests.

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,16 @@ services:
     ports:
       - "6379:6379"
 
+  app:
+    image: alpine:3.22
+    depends_on:
+      # Will start only after the wait-for-dependencies finishes waiting
+      # for both database and cache to be reachable.
+      wait-for-dependencies:
+        condition: service_completed_successfully
+    ports:
+      - "8000:8000"
+
   wait-for-dependencies:
     image: drevops/docker-wait-for-dependencies:25.9.0
     depends_on:
@@ -85,6 +95,16 @@ services:
     ports:
       - "9000:9000"
     command: nc -l -p 9000
+
+  app:
+    image: alpine:3.22
+    depends_on:
+      # Will start only after the wait-for-dependencies finishes waiting
+      # for both api and worker to be reachable.
+      wait-for-dependencies:
+        condition: service_completed_successfully
+    ports:
+      - "8000:8000"
 
   wait-for-dependencies:
     image: drevops/docker-wait-for-dependencies:25.9.0
@@ -117,8 +137,31 @@ npm run test-unit # Run unit tests for validation logic
 npm run test-functional # Run end-to-end tests with Docker
 ```
 
-A new version is automatically published to Docker Hub when a new GitHub release
-is created.
+### Versioning
+
+This project uses [CalVer](https://calver.org/) versioning:
+
+- `YY`: Last two digits of the year, e.g., `25` for 2025.
+- `m`: Numeric month, e.g., April is `4`.
+- `patch`: Patch number for the month, starting at `0`.
+
+Example: `25.4.2` indicates the third patch in April 2025.
+
+### Releasing
+
+Releases are scheduled to occur at a minimum of once per month.
+
+The cross-platform images are built by GitHub actions and pushed to DockerHub:
+
+- `YY.m.patch` tag - when release tag is published on GitHub.
+- `latest` - when release tag is published on GitHub.
+- `canary` - on every push to `main` branch
+
+### Dependencies update
+
+Renovate bot is used to update dependencies. It creates a PR with the changes
+and automatically merges it if CI passes. These changes are then released as
+a `canary` version.
 
 ---
 _This repository was created using the [Scaffold](https://getscaffold.dev/)

--- a/tests/fixtures/docker-compose.cmd.yml
+++ b/tests/fixtures/docker-compose.cmd.yml
@@ -65,6 +65,19 @@ services:
     ports:
       - "8002:8002"
 
+  service3:
+    image: alpine:3.18
+    depends_on:
+      wait-for-dependencies:
+        condition: service_completed_successfully
+    command: >
+      sh -lc "
+        echo \"[service3] Ready\"
+        while true; do nc -l -p 8003 >/dev/null 2>&1; done
+      "
+    ports:
+      - "8003:8003"
+
   wait-for-dependencies:
     build: ../..
     depends_on:

--- a/tests/fixtures/docker-compose.tcp.yml
+++ b/tests/fixtures/docker-compose.tcp.yml
@@ -27,6 +27,19 @@ services:
     ports:
       - "8002:8002"
 
+  service3:
+    image: alpine:3.18
+    depends_on:
+      wait-for-dependencies:
+        condition: service_completed_successfully
+    command: >
+      sh -lc "
+        echo \"[service3] Ready\"
+        while true; do nc -l -p 8003 >/dev/null 2>&1; done
+      "
+    ports:
+      - "8003:8003"
+
   wait-for-dependencies:
     build: ../..
     depends_on:

--- a/tests/functional.bats
+++ b/tests/functional.bats
@@ -17,6 +17,7 @@ load _loader
   assert_success
   assert_output_contains "service1"
   assert_output_contains "service2"
+  assert_output_contains "service3"
   assert_output_not_contains "wait-for-dependencies"
 
   step "Assert the logs content."
@@ -51,6 +52,7 @@ load _loader
   assert_success
   assert_output_contains "service1"
   assert_output_contains "service2"
+  assert_output_contains "service3"
   assert_output_not_contains "wait-for-dependencies"
 
   step "Assert the logs content."


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Documentation
  - Expanded docker-compose examples to include an additional app service that waits for dependencies and exposes port 8003.
  - Added Versioning (CalVer), Releasing cadence (monthly) and Image tagging (YY.m.patch, latest, canary) sections.
  - Documented dependency update workflow and canary release process; removed prior brief Docker Hub note.
- Tests
  - Updated functional tests to expect the additional example service in docker-compose scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->