### PR TITLE
Named the waited-on target in 'still waiting' progress lines and covered 'wait_tcp'.

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -53,7 +53,7 @@ wait_tcp() {
 
     # Print "still waiting" every ~10s, but not on first iteration
     if ((elapsed_time > 0 && elapsed_time % 10 == 0 && elapsed_time != last_still_waiting)); then
-      echo "… still waiting (elapsed ${elapsed_time}s, timeout ${TIMEOUT_LENGTH}s)"
+      echo "… still waiting (tcp): ${host}:${port} (elapsed ${elapsed_time}s, timeout ${TIMEOUT_LENGTH}s)"
       last_still_waiting=$elapsed_time
     fi
 
@@ -81,7 +81,7 @@ wait_cmd() {
 
     # Print "still waiting" every ~10s, but not on first iteration
     if ((elapsed_time > 0 && elapsed_time % 10 == 0 && elapsed_time != last_still_waiting)); then
-      echo "… still waiting (elapsed ${elapsed_time}s, timeout ${TIMEOUT_LENGTH}s)"
+      echo "… still waiting (cmd): ${cmd} (elapsed ${elapsed_time}s, timeout ${TIMEOUT_LENGTH}s)"
       last_still_waiting=$elapsed_time
     fi
 

--- a/tests/unit.bats
+++ b/tests/unit.bats
@@ -256,7 +256,8 @@ load _loader
 
   # Reachable host: 'nc' succeeds immediately.
   mock_set_status "$mock_nc" 0
-  output=$(wait_tcp myhost 1234 2>&1)
+  run wait_tcp myhost 1234
+  assert_success
   assert_output_contains "Waiting (tcp): myhost:1234"
   assert_output_contains "✓ Ready (tcp): myhost:1234"
 
@@ -264,7 +265,8 @@ load _loader
   mock_set_status "$mock_nc" 1
   export TIMEOUT_LENGTH=1
   export SLEEP_LENGTH=1
-  output=$(wait_tcp myhost 1234 2>&1 || true)
+  run wait_tcp myhost 1234
+  assert_failure
   assert_output_contains "Waiting (tcp): myhost:1234"
   assert_output_contains "✗ Timeout after 1s (tcp): myhost:1234"
 }

--- a/tests/unit.bats
+++ b/tests/unit.bats
@@ -149,6 +149,39 @@ load _loader
   assert_output_not_contains "Waiting (cmd): true"
 }
 
+@test "tcp target ready" {
+  mock_nc=$(mock_command nc)
+  mock_set_status "$mock_nc" 0
+  run "$SUT_SCRIPT" "myhost:1234"
+  assert_success
+  assert_output_contains "Waiting (tcp): myhost:1234"
+  assert_output_contains "✓ Ready (tcp): myhost:1234"
+  assert_output_contains "☑ All services have started."
+}
+
+@test "mixed tcp and shell command targets" {
+  mock_nc=$(mock_command nc)
+  mock_set_status "$mock_nc" 0
+  run "$SUT_SCRIPT" "myhost:1234" "true"
+  assert_success
+  assert_output_contains "✓ Ready (tcp): myhost:1234"
+  assert_output_contains "Waiting (cmd): true"
+  assert_output_contains "✓ Ready (cmd): true"
+  assert_output_contains "☑ All services have started."
+}
+
+@test "exit on first failure - tcp" {
+  mock_nc=$(mock_command nc)
+  mock_set_status "$mock_nc" 1
+  export TIMEOUT_LENGTH=1
+  export SLEEP_LENGTH=1
+  run "$SUT_SCRIPT" "myhost:1234" "true"
+  assert_failure
+  assert_output_contains "Waiting (tcp): myhost:1234"
+  assert_output_contains "✗ Timeout after 1s (tcp): myhost:1234"
+  assert_output_not_contains "Waiting (cmd): true"
+}
+
 @test "wait_cmd: command execution and timeout" {
   dataprovider_run_callback() {
     source "$SUT_SCRIPT" >/dev/null 2>&1
@@ -180,22 +213,23 @@ load _loader
   dataprovider_run "dataprovider_run_callback" 3
 }
 
-@test "wait_cmd: still waiting progress messages" {
-  source "$SUT_SCRIPT" >/dev/null 2>&1
-  export TIMEOUT_LENGTH=25
-  export SLEEP_LENGTH=1
+@test "wait_cmd: still waiting names the command" {
+  # Mock 'date' so elapsed time jumps straight to the 10s progress mark and
+  # then past the timeout. This keeps the test instant and deterministic
+  # without real sleeping or relying on wall-clock timing.
+  mock_date=$(mock_command date)
+  mock_set_output "$mock_date" 1000 1
+  mock_set_output "$mock_date" 1010 2
+  mock_set_output "$mock_date" 1011 3
 
-  # Run a command that fails for long enough to trigger progress messages
-  output=$(wait_cmd "sleep 1 && false" 2>&1 || true)
+  export TIMEOUT_LENGTH=10
+  export SLEEP_LENGTH=0
 
-  # Should contain progress messages at 10s and 20s intervals
-  if echo "$output" | grep -q "… still waiting (elapsed 1[0-9]s, timeout 25s)"; then
-    echo "progress_found"
-  else
-    echo "no_progress"
-  fi
+  run wait_cmd "false"
 
-  assert_equal "progress_found" "progress_found"
+  assert_failure
+  assert_output_contains "… still waiting (cmd): false (elapsed 10s, timeout 10s)"
+  assert_output_contains "✗ Timeout after 10s (cmd): false"
 }
 
 @test "wait_cmd: return codes and basic functionality" {
@@ -215,4 +249,61 @@ load _loader
   output=$(wait_cmd "true" 2>&1)
   assert_output_contains "Waiting (cmd): true"
   assert_output_contains "✓ Ready (cmd): true"
+}
+
+@test "wait_tcp: connection check and timeout" {
+  mock_nc=$(mock_command nc)
+
+  # Reachable host: 'nc' succeeds immediately.
+  mock_set_status "$mock_nc" 0
+  output=$(wait_tcp myhost 1234 2>&1)
+  assert_output_contains "Waiting (tcp): myhost:1234"
+  assert_output_contains "✓ Ready (tcp): myhost:1234"
+
+  # Unreachable host: 'nc' keeps failing until the timeout is reached.
+  mock_set_status "$mock_nc" 1
+  export TIMEOUT_LENGTH=1
+  export SLEEP_LENGTH=1
+  output=$(wait_tcp myhost 1234 2>&1 || true)
+  assert_output_contains "Waiting (tcp): myhost:1234"
+  assert_output_contains "✗ Timeout after 1s (tcp): myhost:1234"
+}
+
+@test "wait_tcp: still waiting names the service" {
+  mock_nc=$(mock_command nc)
+  mock_set_status "$mock_nc" 1
+
+  # Mock 'date' so elapsed time jumps straight to the 10s progress mark and
+  # then past the timeout. This keeps the test instant and deterministic
+  # without real sleeping or relying on wall-clock timing.
+  mock_date=$(mock_command date)
+  mock_set_output "$mock_date" 1000 1
+  mock_set_output "$mock_date" 1010 2
+  mock_set_output "$mock_date" 1011 3
+
+  export TIMEOUT_LENGTH=10
+  export SLEEP_LENGTH=0
+
+  run wait_tcp myhost 1234
+
+  assert_failure
+  assert_output_contains "… still waiting (tcp): myhost:1234 (elapsed 10s, timeout 10s)"
+  assert_output_contains "✗ Timeout after 10s (tcp): myhost:1234"
+}
+
+@test "wait_tcp: return codes and basic functionality" {
+  mock_nc=$(mock_command nc)
+
+  # Reachable host returns 0.
+  mock_set_status "$mock_nc" 0
+  run wait_tcp myhost 1234
+  assert_success
+
+  # Unreachable host with timeout returns 1.
+  mock_set_status "$mock_nc" 1
+  export TIMEOUT_LENGTH=1
+  export SLEEP_LENGTH=1
+  run wait_tcp myhost 1234
+  assert_failure
+  assert_equal "$status" 1
 }


### PR DESCRIPTION
## Summary

The periodic "still waiting" progress lines in `entrypoint.sh` previously omitted which target was being waited on, making logs ambiguous when multiple dependencies were in flight. Both `wait_tcp()` and `wait_cmd()` now include the target (host:port for TCP, the command string for shell checks) and a type prefix in their progress output. Unit tests have been expanded to cover `wait_tcp()` for the first time - connection success, timeout, return codes, and the new named progress message - and the existing `wait_cmd` progress test has been rewritten to use mocked `date` output for instant, deterministic assertion on the new message format.

## Changes

**`entrypoint.sh`**
- `wait_tcp()` progress line changed from `… still waiting (elapsed Ns, timeout Ms)` to `… still waiting (tcp): host:port (elapsed Ns, timeout Ms)`
- `wait_cmd()` progress line changed from `… still waiting (elapsed Ns, timeout Ms)` to `… still waiting (cmd): <command> (elapsed Ns, timeout Ms)`

**`tests/unit.bats`**
- Added `wait_tcp: connection check and timeout` - covers success and timeout paths by mocking `nc`
- Added `wait_tcp: still waiting names the service` - mocks `nc` (always failing) and `date` (returns 1000, 1010, 1011) to reach the 10s progress mark instantly and assert the new message format
- Added `wait_tcp: return codes and basic functionality` - confirms exit codes 0 and 1 from `wait_tcp`
- Added `tcp target ready` - integration-level test for TCP success through `main()`
- Added `mixed tcp and shell command targets` - verifies both target types coexist in one invocation
- Added `exit on first failure - tcp` - verifies a TCP timeout aborts before the subsequent shell command runs
- Replaced `wait_cmd: still waiting progress messages` (tautological `assert_equal "progress_found" "progress_found"`) with `wait_cmd: still waiting names the command`, mocking `date` the same way to assert the new `(cmd): <command>` format

## Before / After

```
TCP target (before):
  … still waiting (elapsed 10s, timeout 300s)

TCP target (after):
  … still waiting (tcp): myhost:5432 (elapsed 10s, timeout 300s)

Shell command target (before):
  … still waiting (elapsed 10s, timeout 300s)

Shell command target (after):
  … still waiting (cmd): curl -f http://api:8080/health (elapsed 10s, timeout 300s)
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Wait status messages now include details about which service or command is being monitored, along with elapsed and timeout information.

* **Tests**
  * Expanded test coverage for TCP target handling and wait command behavior with enhanced deterministic testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->